### PR TITLE
Fix typo in LogAction message

### DIFF
--- a/cmd/oauth2_authorize_code.go
+++ b/cmd/oauth2_authorize_code.go
@@ -79,7 +79,7 @@ func (c *OAuth2Cmd) AuthorizationCodeGrantFlow(clientConfig oauth2.ClientConfig,
 	LogSection("Exchange authorization code for token")
 
 	// token exchange
-	exchangeStatus := LogAction("Exchaging authorization code for access token")
+       exchangeStatus := LogAction("Exchanging authorization code for access token")
 
 	if tokenRequest, tokenResponse, err = oauth2.RequestToken(
 		context.Background(),


### PR DESCRIPTION
## Summary
- fix a spelling mistake in `AuthorizationCodeGrantFlow`'s log message

## Testing
- `go vet` *(fails: no packages to vet)*